### PR TITLE
Fixes loading cat image path

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
                             </div>
                             <div class="loading-wrapper" id="loader">
                                 <div class="img-container">
-                                    <img src="/img/loading-cat-face.png" alt="cat face">
+                                    <img src="img/loading-cat-face.png" alt="cat face">
                                 </div>
                                 <strong class="pink-text text-darken-4">Loading...</strong>
                             </div>


### PR DESCRIPTION
I realized that the path that I put for the cat image was with a `/` in front of it, so it was taking from the root of your site.

> Ps.: You can flag it as inappropriate for Hacktoberfest because there is not much done work in here, it was just a minor fix.